### PR TITLE
Use official python:2.7 image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/python
+FROM python:2.7
 MAINTAINER coopermaa77@gmail.com
 
 # arduino for Arduino IDE distribution


### PR DESCRIPTION
dockerfiles/ repository was removed from hub.docker.com
